### PR TITLE
Fix custom field updates

### DIFF
--- a/lib/custom_fields_screen.dart
+++ b/lib/custom_fields_screen.dart
@@ -248,7 +248,11 @@ class CustomFieldsList extends ConsumerWidget {
                 onPressed: () async {
                   if (formKey.currentState!.validate()) {
                     await ref.read(customFieldsControllerProvider.notifier)
-                        .updateCustomField(field.id, controller.text.trim());
+                        .updateCustomField(
+                          field.id,
+                          field.type,
+                          controller.text.trim(),
+                        );
                     if (context.mounted) {
                       Navigator.of(context).pop();
                       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/models.dart
+++ b/lib/models.dart
@@ -84,7 +84,7 @@ class CustomFieldModel {
       id: id,
       name: name ?? this.name,
       type: type,
-      createdAt: createdAt,
+      createdAt: this.createdAt,
       updatedAt: updatedAt ?? DateTime.now(),
     );
   }
@@ -188,7 +188,7 @@ class LeadModel {
       status: status ?? this.status,
       remarks: remarks ?? this.remarks,
       followUp: followUp ?? this.followUp,
-      createdAt: createdAt,
+      createdAt: this.createdAt,
       updatedAt: updatedAt ?? DateTime.now(),
     );
   }

--- a/lib/providers.dart
+++ b/lib/providers.dart
@@ -111,14 +111,18 @@ class CustomFieldsController extends StateNotifier<AsyncValue<void>> {
     }
   }
 
-  Future<void> updateCustomField(String fieldId, String newName) async {
+  Future<void> updateCustomField(
+    String fieldId,
+    CustomFieldType type,
+    String newName,
+  ) async {
     state = const AsyncValue.loading();
     try {
       await FirestoreService.updateCustomField(fieldId, newName);
       state = const AsyncValue.data(null);
 
-      // Refresh all custom fields
-      ref.invalidate(customFieldsProvider);
+      // Refresh the updated custom field list
+      ref.invalidate(customFieldsProvider(type));
     } catch (e) {
       state = AsyncValue.error(e, StackTrace.current);
     }


### PR DESCRIPTION
## Summary
- ensure `CustomFieldModel.copyWith` preserves the creation date
- refresh only the affected custom field list after updates
- pass field type when calling `updateCustomField`
- keep original lead creation timestamp when copying leads

## Testing
- _No tests run per user request_

------
https://chatgpt.com/codex/tasks/task_e_683fd722014883288ecb875c0124df5a